### PR TITLE
Correct documentation on alternate stylesheets

### DIFF
--- a/files/en-us/web/css/alternative_style_sheets/index.md
+++ b/files/en-us/web/css/alternative_style_sheets/index.md
@@ -37,9 +37,9 @@ No matter what style is selected, the rules from the reset.css stylesheet will a
 
 Any stylesheet in a document falls into one of the following categories:
 
-- **Persistent** (no `rel="stylesheet"`, no `title=""`): always applies to the document.
-- **Preferred** (no `rel="stylesheet"`, with `title="…"` specified): applied by default, but {{domxref("StyleSheet.disabled", "disabled", "", 1)}} if an alternate stylesheet is selected. **There can only be one preferred stylesheet**, so providing stylesheets with different title attributes will cause some of them to be ignored.
-- **Alternate** (`rel="alternate stylesheet"`, `title="…"` must be specified): disabled by default, can be selected.
+- **Persistent** (has `rel="stylesheet"`, no `title=""`): always applies to the document.
+- **Preferred** (has `rel="stylesheet"`, with `title="…"` specified): applied by default, but {{domxref("StyleSheet.disabled", "disabled", "", 1)}} if an alternate stylesheet is selected. **There can only be one preferred stylesheet**, so providing stylesheets with different title attributes will cause some of them to be ignored.
+- **Alternate** (`rel="alternate stylesheet"`, with `title="…"` specified): disabled by default, can be selected.
 
 When style sheets are referenced with a `title` attribute on the {{HTMLElement("link", "&lt;link rel=\"stylesheet\"&gt;")}} or {{HTMLElement("style")}} element, the title becomes one of the choices offered to the user. Style sheets linked with the same `title` are part of the same choice. Style sheets linked without a `title` attribute are always applied.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed incorrect information about alternate stylesheets.

### Motivation

All linked stylesheets need `rel="stylesheet"` unlike described in the documentation previously. Just the presence of `rel=alternate` and `title` attributes define the stylesheet’s type.

### Additional details

- https://html.spec.whatwg.org/multipage/links.html#the-link-is-an-alternative-stylesheet
- https://html.spec.whatwg.org/multipage/semantics.html#attr-style-title

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
